### PR TITLE
Added Slightly Modified Memory from Deliverable3

### DIFF
--- a/Deliverable4/processor/memory.vhd
+++ b/Deliverable4/processor/memory.vhd
@@ -1,0 +1,71 @@
+--Adapted from Example 12-15 of Quartus Design and Synthesis handbook
+LIBRARY ieee;
+USE ieee.std_logic_1164.all;
+USE ieee.numeric_std.all;
+
+ENTITY memory IS
+	GENERIC(
+		ram_size : INTEGER := 8192;
+		bit_width : INTEGER := 32;
+		mem_delay : time := 0.1 ns;
+		clock_period : time := 1 ns
+	);
+	PORT (
+		clock: IN STD_LOGIC;
+		writedata: IN STD_LOGIC_VECTOR (bit_width-1 DOWNTO 0);
+		address: IN INTEGER RANGE 0 TO ram_size-1;
+		memwrite: IN STD_LOGIC;
+		memread: IN STD_LOGIC;
+		readdata: OUT STD_LOGIC_VECTOR (bit_width-1 DOWNTO 0);
+		waitrequest: OUT STD_LOGIC
+	);
+END memory;
+
+ARCHITECTURE rtl OF memory IS
+	TYPE MEM IS ARRAY(ram_size-1 downto 0) OF STD_LOGIC_VECTOR(bit_width-1 DOWNTO 0);
+	SIGNAL ram_block: MEM;
+	SIGNAL read_address_reg: INTEGER RANGE 0 to ram_size-1;
+	SIGNAL write_waitreq_reg: STD_LOGIC := '1';
+	SIGNAL read_waitreq_reg: STD_LOGIC := '1';
+BEGIN
+	--This is the main section of the SRAM model
+	mem_process: PROCESS (clock)
+	BEGIN
+		--This is a cheap trick to initialize the SRAM in simulation
+		IF(now < 1 ps)THEN
+			For i in 0 to ram_size-1 LOOP
+				ram_block(i) <= std_logic_vector(to_unsigned(i,bit_width));
+			END LOOP;
+		end if;
+
+		--This is the actual synthesizable SRAM block
+		IF (clock'event AND clock = '1') THEN
+			IF (memwrite = '1') THEN
+				ram_block(address) <= writedata;
+			END IF;
+		read_address_reg <= address;
+		END IF;
+	END PROCESS;
+	readdata <= ram_block(read_address_reg);
+
+
+	--The waitrequest signal is used to vary response time in simulation
+	--Read and write should never happen at the same time.
+	waitreq_w_proc: PROCESS (memwrite)
+	BEGIN
+		IF(memwrite'event AND memwrite = '1')THEN
+			write_waitreq_reg <= '0' after mem_delay, '1' after mem_delay + clock_period;
+
+		END IF;
+	END PROCESS;
+
+	waitreq_r_proc: PROCESS (memread)
+	BEGIN
+		IF(memread'event AND memread = '1')THEN
+			read_waitreq_reg <= '0' after mem_delay, '1' after mem_delay + clock_period;
+		END IF;
+	END PROCESS;
+	waitrequest <= write_waitreq_reg and read_waitreq_reg;
+
+
+END rtl;

--- a/Deliverable4/processor/memory_tb.vhd
+++ b/Deliverable4/processor/memory_tb.vhd
@@ -1,0 +1,90 @@
+LIBRARY ieee;
+USE ieee.std_logic_1164.all;
+USE ieee.numeric_std.all;
+
+ENTITY memory_tb IS
+END memory_tb;
+
+ARCHITECTURE behaviour OF memory_tb IS
+
+  
+    constant bit_width : INTEGER := 32;
+    constant ram_size : INTEGER := 8192;
+    constant clock_period : time := 1 ns;
+    
+--Declare the component that you are testing:
+    COMPONENT memory IS
+        GENERIC(
+          ram_size : INTEGER := ram_size;
+		      bit_width : INTEGER := bit_width;
+		      mem_delay : time := 0.1 ns;
+		      clock_period : time := clock_period
+        );
+        PORT (
+            clock: IN STD_LOGIC;
+            writedata: IN STD_LOGIC_VECTOR (bit_width-1 DOWNTO 0);
+            address: IN INTEGER RANGE 0 TO ram_size-1;
+            memwrite: IN STD_LOGIC := '0';
+            memread: IN STD_LOGIC := '0';
+            readdata: OUT STD_LOGIC_VECTOR (bit_width-1 DOWNTO 0);
+            waitrequest: OUT STD_LOGIC
+        );
+    END COMPONENT;
+    
+    
+
+    --all the input signals with initial values
+    signal clk : std_logic := '0';
+    signal writedata: std_logic_vector(bit_width-1 downto 0);
+    signal address: INTEGER RANGE 0 TO ram_size-1;
+    signal memwrite: STD_LOGIC := '0';
+    signal memread: STD_LOGIC := '0';
+    signal readdata: STD_LOGIC_VECTOR (bit_width-1 DOWNTO 0);
+    signal waitrequest: STD_LOGIC;
+
+BEGIN
+
+    --dut => Device Under Test
+    dut: memory GENERIC MAP(
+            ram_size => 15
+                )
+                PORT MAP(
+                    clk,
+                    writedata,
+                    address,
+                    memwrite,
+                    memread,
+                    readdata,
+                    waitrequest
+                );
+
+    clk_process : process
+    BEGIN
+        clk <= '0';
+        wait for clock_period/2;
+        clk <= '1';
+        wait for clock_period/2;
+    end process;
+
+    test_process : process
+    BEGIN
+        wait for clock_period;
+        address <= 14; 
+        writedata <= X"12345678";
+        memwrite <= '1';
+        
+        --waits are NOT synthesizable and should not be used in a hardware design
+        wait until rising_edge(waitrequest);
+        memwrite <= '0';
+        memread <= '1';
+        wait until rising_edge(waitrequest);
+        assert readdata = x"12345678" report "write unsuccessful" severity error;
+        memread <= '0';
+        report "done testing memory." severity note;
+        wait;
+
+
+    END PROCESS;
+
+ 
+END;


### PR DESCRIPTION
Added the slightly modified Memory.vhd as well as the accompanying testbench (Memory_tb.vhd).

- Changed the Ram_size to 8192
- Changed the bit_width to 32 instead of 8
- Decreased the memory delay to 0.1ns from 10 ns
- Added a bunch of Constants to replace the hard-coded values in Memory and Testbench

Signed-off-by: Fabrice Normandin <fabrice.normandin@gmail.com>